### PR TITLE
Contributing: Added Plugin Resources

### DIFF
--- a/source/_templates/index.rst.j2
+++ b/source/_templates/index.rst.j2
@@ -10,7 +10,7 @@ Contributing
 
 * Improving PRs or issues with the plugin catalog (only the catalog not the plugins themselves) can be made `here <http://github.com/snakemake/snakemake-plugin-catalog>`_.
 * Improving PRs or issues with the plugins themselves can be made at the respective plugin repository (see the docs of each plugin here).
-* Resources for contributing to new plugin development include the `snakemake-interface-executor-plugins <https://github.com/snakemake/snakemake-interface-executor-plugins>`_ (along with the `poetry-snakemake-plugin <https://github.com/snakemake/poetry-snakemake-plugin>`_) and referring to existing plugin repositories.
+* Resources for contributing to new plugin development include the `snakemake-interface-executor-plugins <https://github.com/snakemake/snakemake-interface-executor-plugins>`_ and `snakemake-interface-storage-plugins <https://github.com/snakemake/snakemake-interface-storage-plugins>`_ (along with the `poetry-snakemake-plugin <https://github.com/snakemake/poetry-snakemake-plugin>`_ for automatically generating skeleton code) and referring to existing plugin repositories.
 
 {% for plugin_type, plugins in plugins.items() %}
 .. toctree::

--- a/source/_templates/index.rst.j2
+++ b/source/_templates/index.rst.j2
@@ -8,7 +8,7 @@ Note that plugin support will appear in `Snakemake 8 <https://github.com/snakema
 Contributing
 ------------
 
-* Improving PRs or issues with the plugin catalog (only the catalog not the plugins themselves) can be made at `here <http://github.com/snakemake/snakemake-plugin-catalog>`_.
+* Improving PRs or issues with the plugin catalog (only the catalog not the plugins themselves) can be made `here <http://github.com/snakemake/snakemake-plugin-catalog>`_.
 * Improving PRs or issues with the plugins themselves can be made at the respective plugin repository (see the docs of each plugin here).
 * Resources for contributing to new plugin development include the `snakemake-interface-executor-plugins <https://github.com/snakemake/snakemake-interface-executor-plugins>`_ (along with the `poetry-snakemake-plugin <https://github.com/snakemake/poetry-snakemake-plugin>`_) and by referring to existing plugin repositories.
 

--- a/source/_templates/index.rst.j2
+++ b/source/_templates/index.rst.j2
@@ -10,7 +10,7 @@ Contributing
 
 * Improving PRs or issues with the plugin catalog (only the catalog not the plugins themselves) can be made `here <http://github.com/snakemake/snakemake-plugin-catalog>`_.
 * Improving PRs or issues with the plugins themselves can be made at the respective plugin repository (see the docs of each plugin here).
-* Resources for contributing to new plugin development include the `snakemake-interface-executor-plugins <https://github.com/snakemake/snakemake-interface-executor-plugins>`_ (along with the `poetry-snakemake-plugin <https://github.com/snakemake/poetry-snakemake-plugin>`_) and by referring to existing plugin repositories.
+* Resources for contributing to new plugin development include the `snakemake-interface-executor-plugins <https://github.com/snakemake/snakemake-interface-executor-plugins>`_ (along with the `poetry-snakemake-plugin <https://github.com/snakemake/poetry-snakemake-plugin>`_) and referring to existing plugin repositories.
 
 {% for plugin_type, plugins in plugins.items() %}
 .. toctree::

--- a/source/_templates/index.rst.j2
+++ b/source/_templates/index.rst.j2
@@ -8,8 +8,9 @@ Note that plugin support will appear in `Snakemake 8 <https://github.com/snakema
 Contributing
 ------------
 
-* Improving PRs or issues with the plugin catalog (only the catalog not the plugins themselves) can be made at http://github.com/snakemake/snakemake-plugin-catalog.
+* Improving PRs or issues with the plugin catalog (only the catalog not the plugins themselves) can be made at `here <http://github.com/snakemake/snakemake-plugin-catalog>`_.
 * Improving PRs or issues with the plugins themselves can be made at the respective plugin repository (see the docs of each plugin here).
+* Resources for contributing to new plugin development include the `snakemake-interface-executor-plugins <https://github.com/snakemake/snakemake-interface-executor-plugins>`_ (along with the `poetry-snakemake-plugin <https://github.com/snakemake/poetry-snakemake-plugin>`_) and by referring to existing plugin repositories.
 
 {% for plugin_type, plugins in plugins.items() %}
 .. toctree::


### PR DESCRIPTION
- Appended a bullet point under `Contributing` regarding resources for contributing to plugin development.

- Revised the inline hyperlink in the first bullet point.