### PR TITLE
Add mamba installation command example

### DIFF
--- a/source/_templates/executor_plugin.rst.j2
+++ b/source/_templates/executor_plugin.rst.j2
@@ -39,9 +39,13 @@ Snakemake executor plugin: {{ plugin_name }}
 Installation
 ------------
 
-Install this plugin by installing it with pip or mamba, e.g.::
+Install this plugin using either pip::
 
     pip install snakemake-executor-plugin-{{ plugin_name }}
+
+or mamba::
+
+    mamba install snakemake-executor-plugin-{{ plugin_name }}
 
 Usage
 -----


### PR DESCRIPTION
People don't like to read, so by linking my cluster's usage docs to the plugins catalog I consistently get people installing this via pip instead of mamba, which is not ideal in our case.

Hope it's acceptable to add an explicit mamba example which should help people realise there's another option.