### PR TITLE
Allow lambda functions as a default settings argument

### DIFF
--- a/source/collect_plugins.py
+++ b/source/collect_plugins.py
@@ -87,8 +87,13 @@ class MetadataCollector:
     def get_settings(self) -> List[Dict[str, Any]]:
         info = self.extract_info(
             "import json; "
+            "from inspect import getsourcelines; "
             "fmt_type = lambda thetype: thetype.__name__ if thetype is not None else None; "
-            "fmt_setting_item = lambda key, value: (key, fmt_type(value)) if key == 'type' else (key, value); "
+            "get_source_lines_lambda = lambda value: getsourcelines(value)[0][0][:-1].split('=')[-1][:-1]; "
+            "fmt_setting_item = lambda key, value: ( "
+            "(key, fmt_type(value)) if key == 'type' else "
+            "(key, get_source_lines_lambda(value)) if hasattr(value, '__name__') and fmt_type(value) == '<lambda>' else "
+            "(key, value)); "
             "fmt_setting = lambda setting: dict(map(lambda item: fmt_setting_item(*item), setting.items())); "
             "print(json.dumps(list(map(fmt_setting, plugin.get_settings_info()))))"
         )


### PR DESCRIPTION
This PR aims to fix the documentation for `snakemake-storage-plugin-xrootd` see e.g. https://github.com/snakemake/snakemake-plugin-catalog/actions/runs/10868235436/job/30157931963#step:5:68 and issue https://github.com/snakemake/snakemake-storage-plugin-xrootd/issues/11.

The failure is caused when the catalog attempts to serialise the default settings arguments, one of which is a lambda function which cannot be serialised (the setting `url_decorator=lambda x: x`).

This PR modifies the code used to get the settings info so that if an argument is a lambda function it will render the lambda function code as a string (using `inspect.getsourcelines()`) and save that instead i.e. instead of attempting to serialise the lambda function itself it will instead save the string: `"lambda x: x"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced settings formatting to provide clearer output when processing lambda functions.

- **Bug Fixes**
	- Improved handling and introspection of lambda functions in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->