### PR TITLE
feat: Add alt text for last commit badges in plugin template

### DIFF
--- a/source/_templates/plugin_base.rst.j2
+++ b/source/_templates/plugin_base.rst.j2
@@ -12,6 +12,18 @@ Snakemake {% block type %}{% endblock %} plugin: {{ plugin_name }}
    :target: #
 {% endif %}
 
+{% if repository_type == "github" and repository is not none %}
+{% set repo = repository.replace("https://github.com/", "") %}
+.. image:: https://img.shields.io/github/last-commit/{{ repo }}
+   :alt: GitHub - Last commit
+   :target: {{ repository }}
+{% elif repository_type == "gitlab" and repository is not none %}
+{% set repo = repository.replace("https://gitlab.com/", "") %}
+.. image:: https://img.shields.io/gitlab/last-commit/{{ repo }}
+   :alt: GitLab - Last commit
+   :target: {{ repository }}
+{% endif %}
+
 {% for author in authors %}
 .. image:: https://img.shields.io/badge/author-{{author|replace("-","--")|urlencode}}-purple?color=%23064e3b
    :target: https://pypi.org/project/{{ package_name }}

--- a/source/_templates/plugin_base.rst.j2
+++ b/source/_templates/plugin_base.rst.j2
@@ -13,12 +13,12 @@ Snakemake {% block type %}{% endblock %} plugin: {{ plugin_name }}
 {% endif %}
 
 {% if repository_type == "github" and repository is not none %}
-{% set repo = repository.replace("https://github.com/", "") %}
+{% set repo = repository.replace("https://github.com/", "").replace(".git", "").rstrip("/") %}
 .. image:: https://img.shields.io/github/last-commit/{{ repo }}
    :alt: GitHub - Last commit
    :target: {{ repository }}
 {% elif repository_type == "gitlab" and repository is not none %}
-{% set repo = repository.replace("https://gitlab.com/", "") %}
+{% set repo = repository.replace("https://gitlab.com/", "").replace(".git", "").rstrip("/") %}
 .. image:: https://img.shields.io/gitlab/last-commit/{{ repo }}
    :alt: GitLab - Last commit
    :target: {{ repository }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added last-commit badges for GitHub and GitLab repositories. When a repository link is configured, a platform-specific badge shows the latest commit info with descriptive alt text and a direct link to the commit. These badges appear alongside existing repository and author badges and handle platform URLs cleanly for accurate linking and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->